### PR TITLE
fix: [code-smell] UnboundLocalError when iterations=0

### DIFF
--- a/src/dynamic_programming/valuefunctionhelpers.py
+++ b/src/dynamic_programming/valuefunctionhelpers.py
@@ -20,6 +20,7 @@ class ValueFunctionHelpers:
             iterations: int = 100,
             epsilon: float = 0.05):
         prev_value_function = ValueFunctionHelpers.get_value_function(mdp)
+        current_value_function = prev_value_function
         value_function_diff = float("inf")
         i = 0
 


### PR DESCRIPTION
## Summary

Automated fix for [CODE-190](https://linear.app/shehio/issue/CODE-190/code-smell-unboundlocalerror-when-iterations0).

**Issue:** [code-smell] UnboundLocalError when iterations=0
**Description:** `value_iteration` returns `current_value_function` which is only assigned inside the while loop. If called with `iterations=0`, the loop never executes and the return statement raises `UnboundLocalError`.

**Location:** `src/dynamic_programming/valuefunctionhelpers.py:31`

**Repo:** shehio/tabular-rl
**Severity:** medium

---

*Filed automatically by Sync agent.*

---
_Generated by Sync agent._