### PR TITLE
fix: [code-smell] Inverted logic in value function difference check

### DIFF
--- a/src/dynamic_programming/valuefunctionhelpers.py
+++ b/src/dynamic_programming/valuefunctionhelpers.py
@@ -48,7 +48,7 @@ class ValueFunctionHelpers:
         first_vf_keys = first_value_function.value_dict.keys()
         second_vf_keys = second_value_function.value_dict.keys()
 
-        if len(np.intersect1d(first_vf_keys, second_vf_keys)) == len(first_vf_keys):
+        if len(np.intersect1d(first_vf_keys, second_vf_keys)) != len(first_vf_keys):
             raise ValueError("There seems to be different states between the value functions.")
 
         if len(first_vf_keys) >= len(second_vf_keys):


### PR DESCRIPTION
## Summary

Automated fix for [CODE-189](https://linear.app/shehio/issue/CODE-189/code-smell-inverted-logic-in-value-function-difference-check).

**Issue:** [code-smell] Inverted logic in value function difference check
**Description:** The condition `if len(np.intersect1d(...)) == len(first_vf_keys)` raises an error when the keys ARE identical (intersection equals the full set). This is backwards — it should raise when they differ. As written, `get_value_function_difference` always raises `ValueError` on valid inputs and only succeeds when states mismatch, which is the opposite of correct behavior.

**Location:** `src/dynamic_programming/valuefunctionhelpers.py:42`

**Repo:** shehio/tabular-rl
**Severity:** high

---

*Filed automatically by Sync agent.*

---
_Generated by Sync agent._