### PR TITLE
fix: [code-smell] Exact float comparison for probability sum

### DIFF
--- a/src/building_blocks/probabilisticaction.py
+++ b/src/building_blocks/probabilisticaction.py
@@ -52,7 +52,7 @@ class ProbabilisticAction:
             raise TypeError("The dtype of probabilities array has to be an np numerical type.")
         if probabilities.size == 0:
             raise ValueError("Probabilities array can't be empty.")
-        if np.sum(probabilities) != 1.0:
+        if not np.isclose(np.sum(probabilities), 1.0):
             raise ValueError("The sample space probabilities have to sum to 1.0.")
 
     def __create_derived_actions(self, rewards, probabilities, states):


### PR DESCRIPTION
## Summary

Automated fix for [CODE-191](https://linear.app/shehio/issue/CODE-191/code-smell-exact-float-comparison-for-probability-sum).

**Issue:** [code-smell] Exact float comparison for probability sum
**Description:** `np.sum(probabilities) != 1.0` will reject valid probability arrays due to floating-point rounding (e.g., `[0.1, 0.2, 0.7]` sums to `0.9999999999999999`). Use `np.isclose(np.sum(probabilities), 1.0)` instead.

**Location:** `src/building_blocks/probabilisticaction.py:42`

**Repo:** shehio/tabular-rl
**Severity:** medium

---

*Filed automatically by Sync agent.*

---
_Generated by Sync agent._