### PR TITLE
fix: [code-smell] Boolean used as integer counter

### DIFF
--- a/src/monte_carlo/montecarlohelpers.py
+++ b/src/monte_carlo/montecarlohelpers.py
@@ -121,7 +121,7 @@ class MonteCarloHelpers:
             stable_count,
             episodes_count):
         old_policy = Policy(mdp)
-        policy_is_stable = False
+        policy_is_stable = 0
         i = 0
         while policy_is_stable < stable_count:
             mdp = policy_evaluation_method(


### PR DESCRIPTION
## Summary

Automated fix for [CODE-192](https://linear.app/shehio/issue/CODE-192/code-smell-boolean-used-as-integer-counter).

**Issue:** [code-smell] Boolean used as integer counter
**Description:** `policy_is_stable` is initialized as `False` (boolean), then compared with `< stable_count` and incremented with `+ 1`. This works accidentally because `False == 0` in Python, but conflates a boolean flag with a counter. Should be initialized as `0`.

**Location:** `src/monte_carlo/montecarlohelpers.py:114`

**Repo:** shehio/tabular-rl
**Severity:** medium

---

*Filed automatically by Sync agent.*

---
_Generated by Sync agent._