### PR TITLE
fix: [code-smell] Unused variable in __get_max_value_action_from_state

### DIFF
--- a/src/building_blocks/qfunctionhelpers.py
+++ b/src/building_blocks/qfunctionhelpers.py
@@ -57,13 +57,11 @@ class QFunctionHelpers:
 
     @staticmethod
     def __get_max_value_action_from_state(qdict, state):
-        values = qdict[state].values()
         amax = np.argmax(list(qdict[state].values()))
         return state, list(qdict[state].keys())[amax]
 
     @staticmethod
     def __get_max_value_from_state(qdict, state):
-        values = qdict[state].values()
         return state, max(qdict[state].values())
 
     @staticmethod


### PR DESCRIPTION
## Summary

Automated fix for [CODE-193](https://linear.app/shehio/issue/CODE-193/code-smell-unused-variable-in-get-max-value-action-from-state).

**Issue:** [code-smell] Unused variable in __get_max_value_action_from_state
**Description:** `values = qdict[state].values()` is assigned but never used. The same pattern repeats in `__get_max_value_from_state` at line 58.

**Location:** `src/building_blocks/qfunctionhelpers.py:53`

**Repo:** shehio/tabular-rl
**Severity:** low

---

*Filed automatically by Sync agent.*

---
_Generated by Sync agent._