### PR TITLE
fix: UnboundLocalError when while loop body never executes

### DIFF
--- a/src/dynamic_programming/policyhelpers.py
+++ b/src/dynamic_programming/policyhelpers.py
@@ -60,6 +60,7 @@ class PolicyHelpers:
         prev_value_function = PolicyHelpers.__get_value_function_from_policy(mdp, policy, discount_factor)
         mdp.update_values(prev_value_function)
 
+        current_value_function = prev_value_function
         value_function_diff = float("inf")
 
         while value_function_diff > epsilon: # Should this break anyway after a particular number of iterations?


### PR DESCRIPTION
## Summary

In `evaluate_policy`, if `value_function_diff` starts <= `epsilon`, the while loop never executes, and `current_value_function` is never assigned — yet it's returned on line 74. This will raise `UnboundLocalError`.

Fixes [CODE-413](https://linear.app/shehio/issue/CODE-413/code-smell-unboundlocalerror-when-while-loop-body-never-executes).

## Changes

- `src/dynamic_programming/policyhelpers.py`
